### PR TITLE
quick patch for crash

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/capturexp/CaptureXP.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/capturexp/CaptureXP.kt
@@ -24,8 +24,8 @@ object CaptureXP : ModInitializer {
 
     private fun handleCaptureInBattle(event: PokemonCapturedEvent) {
         val battle = Cobblemon.battleRegistry.getBattleByParticipatingPlayer(event.player) ?: return
-        val caughtBattleMonActor = battle.actors.find { it.uuid == event.pokemon.uuid }!!
-        val caughtBattleMon = caughtBattleMonActor.pokemonList.find { it.uuid == event.pokemon.uuid }!!
+        val caughtBattleMonActor = battle.actors.find { it.uuid == event.pokemon.uuid } ?: return
+        val caughtBattleMon = caughtBattleMonActor.pokemonList.find { it.uuid == event.pokemon.uuid } ?: return
 
         caughtBattleMonActor.getSide().getOppositeSide().actors.forEach { opponentActor ->
             opponentActor.pokemonList.filter {


### PR DESCRIPTION
sloppy patch, but it'll do for now.
it means if you trigger the circumstance where we lose the ref to the previous battle, you're out of luck for Capture XP on that battle. wait for the previous battle (including captures) to resolve before moving on to another one.